### PR TITLE
[Define] change struct EmployeeInfo member types

### DIFF
--- a/dynamic/Define.h
+++ b/dynamic/Define.h
@@ -3,16 +3,14 @@
 
 enum OPTION { PRINT_BRIEF, PRINT_DETAIL, LRI };
 enum OPERATION_TYPE { ADD, DEL, SCH, MOD };
-enum CAREER_LEVEL { CL1, CL2, CL3, CL4 };
-enum CERTI_LEVEL { ADV, PRO, EX };
 
 struct EmployeeInfo {
-	int employeeNum;
+	std::string employeeNum;
 	std::string name;
-	CAREER_LEVEL cl;
-	int phoneNum;
-	int birthday;
-	CERTI_LEVEL certi;
+	std::string cl;
+	std::string phoneNum;
+	std::string birthday;
+	std::string certi;
 };
 
 struct ParserResult {


### PR DESCRIPTION
Since int cannot store numbers which starts with 0, it must be treated
as string (ex. "01011111111")