### PR TITLE
[Feature] DataBase 자료구조 변경

### DIFF
--- a/dynamic/DBManager.cpp
+++ b/dynamic/DBManager.cpp
@@ -14,7 +14,7 @@ std::string DBManager::query(const std::string& queryString)
     Operator* pOperator = pOperatorFactory->getOperator(parseResult);
     Searcher* pSearcher = pSearcherFactory->getSearcher(parseResult);
 
-    std::map<std::string, EmployeeInfo> lists = pSearcher->search(parseResult);
+    std::map<int, EmployeeInfo> lists = pSearcher->search(parseResult);
     pOperator->operate(&lists, parseResult);
 
     return Printer::getPrintString(parseResult, lists);

--- a/dynamic/DBManager.h
+++ b/dynamic/DBManager.h
@@ -18,7 +18,7 @@ public:
     std::string query(const std::string& queryString);
 
 private:
-    std::map<std::string, EmployeeInfo> database_;
+    std::map<int, EmployeeInfo> database_;
     IFactoryOperator *pOperatorFactory;
     IFactorySearcher *pSearcherFactory;
 };

--- a/dynamic/GlobalMethod.cpp
+++ b/dynamic/GlobalMethod.cpp
@@ -2,12 +2,13 @@
 #include <sstream>
 #include <iostream>
 
-std::string getKeyFromEmployeeNum(const std::string& employeeNum) {
+int getKeyFromEmployeeNum(const std::string& employeeNum) {
+	std::string fullString;
 	if (employeeNum.front() == '6' || employeeNum.front() == '7' || employeeNum.front() == '8' || employeeNum.front() == '9') {
-		return "19" + employeeNum;
+		return(std::stoi("19" + employeeNum));
 	}
 
-	return "20" + employeeNum;
+	return(std::stoi("20" + employeeNum));
 }
 
 std::vector<std::string> splitString(const std::string& targetStr, const char delimiter) {

--- a/dynamic/GlobalMethod.h
+++ b/dynamic/GlobalMethod.h
@@ -3,4 +3,4 @@
 #include <vector>
 
 std::vector<std::string> splitString(const std::string& targetStr, const char delimiter);
-std::string getKeyFromEmployeeNum(const std::string& employeeNum);
+int getKeyFromEmployeeNum(const std::string& employeeNum);

--- a/dynamic/Operator.cpp
+++ b/dynamic/Operator.cpp
@@ -1,7 +1,7 @@
 #include "Operator.h"
 #include "GlobalMethod.h"
 
-void AddOperator::operate(const std::map<std::string, EmployeeInfo>* pSearchedDb, const ParserResult& parserResult) {
+void AddOperator::operate(const std::map<int, EmployeeInfo>* pSearchedDb, const ParserResult& parserResult) {
 	if (pSearchedDb->size() == ALREADY_INCLUDED_DATABASE) {
 		throw std::invalid_argument("ERROR: Already included database");
 		return;
@@ -11,13 +11,13 @@ void AddOperator::operate(const std::map<std::string, EmployeeInfo>* pSearchedDb
 }
 
 void AddOperator::addDataBase(const EmployeeInfo& inputEmployeeInfo) {
-	std::string key = getKeyFromEmployeeNum(inputEmployeeInfo.employeeNum);
+	int key = getKeyFromEmployeeNum(inputEmployeeInfo.employeeNum);
 	(*pdataBase_)[key] = inputEmployeeInfo;
 	return;
 }
 
 
-void DeleteOperator::operate(const std::map<std::string, EmployeeInfo>* pSearchedDb, const ParserResult& parserResult) {
+void DeleteOperator::operate(const std::map<int, EmployeeInfo>* pSearchedDb, const ParserResult& parserResult) {
 	for (const auto& searchedInfo : (*pSearchedDb)) {
 		(*pdataBase_).erase(searchedInfo.first);
 	}
@@ -25,12 +25,12 @@ void DeleteOperator::operate(const std::map<std::string, EmployeeInfo>* pSearche
 }
 
 
-void SearchOperator::operate(const std::map<std::string, EmployeeInfo>* pSearchedDb, const ParserResult& parserResult) {
+void SearchOperator::operate(const std::map<int, EmployeeInfo>* pSearchedDb, const ParserResult& parserResult) {
 	return;
 }
 
 
-void ModifyOperator::operate(const std::map<std::string, EmployeeInfo>* pSearchedDb, const ParserResult& parserResult) {
+void ModifyOperator::operate(const std::map<int, EmployeeInfo>* pSearchedDb, const ParserResult& parserResult) {
 	for (const auto& searchedInfo : (*pSearchedDb)) {
 		if (parserResult.changeColumn == "name") {
 			(*pdataBase_)[searchedInfo.first].name = parserResult.changeData;
@@ -51,7 +51,7 @@ void ModifyOperator::operate(const std::map<std::string, EmployeeInfo>* pSearche
 	return;
 }
 
-FactoryOperator::FactoryOperator(std::map<std::string, EmployeeInfo>* pDb) {
+FactoryOperator::FactoryOperator(std::map<int, EmployeeInfo>* pDb) {
 	pAddOperator_ = new AddOperator(pDb);
 	pDeleteOperator_ = new DeleteOperator(pDb);
 	pSearchOperator_ = new SearchOperator(pDb);

--- a/dynamic/Operator.h
+++ b/dynamic/Operator.h
@@ -5,39 +5,39 @@
 
 class Operator {
 public:
-	Operator(std::map<std::string, EmployeeInfo>* pDb) :pdataBase_(pDb) {};
+	Operator(std::map<int, EmployeeInfo>* pDb) :pdataBase_(pDb) {};
 	virtual ~Operator() {};
-	virtual void operate(const std::map<std::string, EmployeeInfo>* pSearchDb, const ParserResult& parserResult) = 0;
+	virtual void operate(const std::map<int, EmployeeInfo>* pSearchDb, const ParserResult& parserResult) = 0;
 	
 protected:
-	std::map<std::string, EmployeeInfo>* pdataBase_;
+	std::map<int, EmployeeInfo>* pdataBase_;
 };
 
 
 class AddOperator : public Operator {
 public:
-	AddOperator(std::map<std::string, EmployeeInfo>* pDb) :Operator(pDb) {};
-	void operate(const std::map<std::string, EmployeeInfo>* pSearchedDb, const ParserResult& parserResult) override;
+	AddOperator(std::map<int, EmployeeInfo>* pDb) :Operator(pDb) {};
+	void operate(const std::map<int, EmployeeInfo>* pSearchedDb, const ParserResult& parserResult) override;
 private:
 	void addDataBase(const EmployeeInfo& inputEmployeeInfo);
 };
 
 class DeleteOperator : public Operator {
 public:
-	DeleteOperator(std::map<std::string, EmployeeInfo>* pDb) :Operator(pDb) {};
-	void operate(const std::map<std::string, EmployeeInfo>* pSearchedDb, const ParserResult& parserResult) override;
+	DeleteOperator(std::map<int, EmployeeInfo>* pDb) :Operator(pDb) {};
+	void operate(const std::map<int, EmployeeInfo>* pSearchedDb, const ParserResult& parserResult) override;
 };
 
 class SearchOperator : public Operator {
 public:
-	SearchOperator(std::map<std::string, EmployeeInfo>* pDb) :Operator(pDb) {};
-	void operate(const std::map<std::string, EmployeeInfo>* pSearchedDb, const ParserResult& parserResult) override;
+	SearchOperator(std::map<int, EmployeeInfo>* pDb) :Operator(pDb) {};
+	void operate(const std::map<int, EmployeeInfo>* pSearchedDb, const ParserResult& parserResult) override;
 };
 
 class ModifyOperator : public Operator {
 public:
-	ModifyOperator(std::map<std::string, EmployeeInfo>* pDb) :Operator(pDb) {};
-	void operate(const std::map<std::string, EmployeeInfo>* pSearchedDb, const ParserResult& parserResult) override;
+	ModifyOperator(std::map<int, EmployeeInfo>* pDb) :Operator(pDb) {};
+	void operate(const std::map<int, EmployeeInfo>* pSearchedDb, const ParserResult& parserResult) override;
 };
 
 
@@ -51,7 +51,7 @@ public:
 
 class FactoryOperator : public IFactoryOperator {
 public:
-	FactoryOperator(std::map<std::string, EmployeeInfo>* pdataBase);
+	FactoryOperator(std::map<int, EmployeeInfo>* pdataBase);
 	Operator* getOperator(ParserResult& parserResult) override;
 	~FactoryOperator() {
 		delete pAddOperator_;

--- a/dynamic/OperatorTest.cpp
+++ b/dynamic/OperatorTest.cpp
@@ -2,7 +2,7 @@
 #include "Operator.h"
 
 namespace {
-	void IsEmployeeInfoMatched(const std::map<std::string, EmployeeInfo>& dataBase, const std::string& key,
+	void IsEmployeeInfoMatched(const std::map<int, EmployeeInfo>& dataBase, int key,
 		const std::string& employeeNum, const std::string& name, const std::string& cl,
 		const std::string& phoneNum, const std::string& birthday, const std::string& certi) {
 		EXPECT_EQ(dataBase.at(key).employeeNum, employeeNum);
@@ -16,10 +16,10 @@ namespace {
 
 
 TEST(OPERATORTEST, AddOperatorTest) {
-	std::map<std::string, EmployeeInfo> dataBase;
+	std::map<int, EmployeeInfo> dataBase;
 	Operator* pAddOper = new AddOperator(&dataBase);
 
-	std::map<std::string, EmployeeInfo> emptyDataBase;
+	std::map<int, EmployeeInfo> emptyDataBase;
 	ParserResult addParserResult = { OPERATION_TYPE::ADD,
 									OPTION1::NONE,
 									OPTION2::NONE,
@@ -40,15 +40,15 @@ TEST(OPERATORTEST, AddOperatorTest) {
 	for (const auto& employee : dataBase) {
 		EXPECT_EQ(employee.second.employeeNum, "01122329");
 	}
-	IsEmployeeInfoMatched(dataBase, "2001122329", "01122329", "DN WD", "CL4", "010-7174-5680", "20071117", "PRO");
+	IsEmployeeInfoMatched(dataBase, 2001122329, "01122329", "DN WD", "CL4", "010-7174-5680", "20071117", "PRO");
 }
 
 TEST(OPERATORTEST, DeleteOperatorTest) {
-		std::map<std::string, EmployeeInfo> dataBase;
+		std::map<int, EmployeeInfo> dataBase;
 		Operator* pAddOper = new AddOperator(&dataBase);
 		Operator* pDelOper = new DeleteOperator(&dataBase);
 
-		std::map<std::string, EmployeeInfo> searchedDelDataBase;
+		std::map<int, EmployeeInfo> searchedDelDataBase;
 		ParserResult addParserResult = { OPERATION_TYPE::ADD,
 										OPTION1::NONE,
 										OPTION2::NONE,
@@ -63,7 +63,7 @@ TEST(OPERATORTEST, DeleteOperatorTest) {
 		pAddOper->operate(&searchedDelDataBase, addParserResult);
 
 		EXPECT_EQ(dataBase.size(), 1);
-		searchedDelDataBase["2001122329"] = EmployeeInfo{ "01122329", "DN WD", "CL4", "010-7174-5680", "20071117", "PRO" };
+		searchedDelDataBase[2001122329] = EmployeeInfo{ "01122329", "DN WD", "CL4", "010-7174-5680", "20071117", "PRO" };
 
 		pDelOper->operate(&searchedDelDataBase, addParserResult);
 
@@ -71,11 +71,11 @@ TEST(OPERATORTEST, DeleteOperatorTest) {
 }
 
 TEST(OPERATORTEST, ModifyOperatorPositiveTest) {
-	std::map<std::string, EmployeeInfo> dataBase;
+	std::map<int, EmployeeInfo> dataBase;
 	Operator* pAddOper = new AddOperator(&dataBase);
 	Operator* pModOper = new ModifyOperator(&dataBase);
 
-	std::map<std::string, EmployeeInfo> searchedModDataBase;
+	std::map<int, EmployeeInfo> searchedModDataBase;
 
 	ParserResult addParserResult = { OPERATION_TYPE::ADD,
 								OPTION1::NONE,
@@ -97,9 +97,9 @@ TEST(OPERATORTEST, ModifyOperatorPositiveTest) {
 
 	EXPECT_EQ(dataBase.size(), 3);
 
-	searchedModDataBase["2001122329"] = EmployeeInfo{ "01122329", "DN WD", "CL4", "010-7174-5680", "20071117", "PRO" };
-	searchedModDataBase["2008108827"] = EmployeeInfo{ "08108827", "RTAH VNUP", "CL3", "010-9031-2726", "19780417", "ADV" };
-	searchedModDataBase["1985125741"] = EmployeeInfo{ "85125741", "FBAH RTIJ", "CL1", "010-8900-1478", "19780228", "ADV" };
+	searchedModDataBase[2001122329] = EmployeeInfo{ "01122329", "DN WD", "CL4", "010-7174-5680", "20071117", "PRO" };
+	searchedModDataBase[2008108827] = EmployeeInfo{ "08108827", "RTAH VNUP", "CL3", "010-9031-2726", "19780417", "ADV" };
+	searchedModDataBase[1985125741] = EmployeeInfo{ "85125741", "FBAH RTIJ", "CL1", "010-8900-1478", "19780228", "ADV" };
 
 	ParserResult modifyParserResult = { OPERATION_TYPE::ADD,
 								OPTION1::NONE,
@@ -116,55 +116,55 @@ TEST(OPERATORTEST, ModifyOperatorPositiveTest) {
 	pModOper->operate(&searchedModDataBase, modifyParserResult);
 
 	
-	IsEmployeeInfoMatched(dataBase, "2001122329", "01122329", "DN WD", "CL4", "010-7174-5680", "20071117", "EX");
-	IsEmployeeInfoMatched(dataBase, "2008108827", "08108827", "RTAH VNUP", "CL3", "010-9031-2726", "19780417", "EX");
-	IsEmployeeInfoMatched(dataBase, "1985125741", "85125741", "FBAH RTIJ", "CL1", "010-8900-1478", "19780228", "EX");
+	IsEmployeeInfoMatched(dataBase, 2001122329, "01122329", "DN WD", "CL4", "010-7174-5680", "20071117", "EX");
+	IsEmployeeInfoMatched(dataBase, 2008108827, "08108827", "RTAH VNUP", "CL3", "010-9031-2726", "19780417", "EX");
+	IsEmployeeInfoMatched(dataBase, 1985125741, "85125741", "FBAH RTIJ", "CL1", "010-8900-1478", "19780228", "EX");
 
 
 	modifyParserResult.changeColumn = "name";
 	modifyParserResult.changeData = "HYUN JUN SHIN";
 	pModOper->operate(&searchedModDataBase, modifyParserResult);
 
-	IsEmployeeInfoMatched(dataBase, "2001122329", "01122329", "HYUN JUN SHIN", "CL4", "010-7174-5680", "20071117", "EX");
-	IsEmployeeInfoMatched(dataBase, "2008108827", "08108827", "HYUN JUN SHIN", "CL3", "010-9031-2726", "19780417", "EX");
-	IsEmployeeInfoMatched(dataBase, "1985125741", "85125741", "HYUN JUN SHIN", "CL1", "010-8900-1478", "19780228", "EX");
+	IsEmployeeInfoMatched(dataBase, 2001122329, "01122329", "HYUN JUN SHIN", "CL4", "010-7174-5680", "20071117", "EX");
+	IsEmployeeInfoMatched(dataBase, 2008108827, "08108827", "HYUN JUN SHIN", "CL3", "010-9031-2726", "19780417", "EX");
+	IsEmployeeInfoMatched(dataBase, 1985125741, "85125741", "HYUN JUN SHIN", "CL1", "010-8900-1478", "19780228", "EX");
 
 
 	modifyParserResult.changeColumn = "cl";
 	modifyParserResult.changeData = "CL2";
 	pModOper->operate(&searchedModDataBase, modifyParserResult);
 
-	IsEmployeeInfoMatched(dataBase, "2001122329", "01122329", "HYUN JUN SHIN", "CL2", "010-7174-5680", "20071117", "EX");
-	IsEmployeeInfoMatched(dataBase, "2008108827", "08108827", "HYUN JUN SHIN", "CL2", "010-9031-2726", "19780417", "EX");
-	IsEmployeeInfoMatched(dataBase, "1985125741", "85125741", "HYUN JUN SHIN", "CL2", "010-8900-1478", "19780228", "EX");
+	IsEmployeeInfoMatched(dataBase, 2001122329, "01122329", "HYUN JUN SHIN", "CL2", "010-7174-5680", "20071117", "EX");
+	IsEmployeeInfoMatched(dataBase, 2008108827, "08108827", "HYUN JUN SHIN", "CL2", "010-9031-2726", "19780417", "EX");
+	IsEmployeeInfoMatched(dataBase, 1985125741, "85125741", "HYUN JUN SHIN", "CL2", "010-8900-1478", "19780228", "EX");
 
 	modifyParserResult.changeColumn = "phoneNum";
 	modifyParserResult.changeData = "010-4233-7244";
 	pModOper->operate(&searchedModDataBase, modifyParserResult);
 
-	IsEmployeeInfoMatched(dataBase, "2001122329", "01122329", "HYUN JUN SHIN", "CL2", "010-4233-7244", "20071117", "EX");
-	IsEmployeeInfoMatched(dataBase, "2008108827", "08108827", "HYUN JUN SHIN", "CL2", "010-4233-7244", "19780417", "EX");
-	IsEmployeeInfoMatched(dataBase, "1985125741", "85125741", "HYUN JUN SHIN", "CL2", "010-4233-7244", "19780228", "EX");
+	IsEmployeeInfoMatched(dataBase, 2001122329, "01122329", "HYUN JUN SHIN", "CL2", "010-4233-7244", "20071117", "EX");
+	IsEmployeeInfoMatched(dataBase, 2008108827, "08108827", "HYUN JUN SHIN", "CL2", "010-4233-7244", "19780417", "EX");
+	IsEmployeeInfoMatched(dataBase, 1985125741, "85125741", "HYUN JUN SHIN", "CL2", "010-4233-7244", "19780228", "EX");
 
 
 	modifyParserResult.changeColumn = "birthday";
 	modifyParserResult.changeData = "20030105";
 	pModOper->operate(&searchedModDataBase, modifyParserResult);
 
-	IsEmployeeInfoMatched(dataBase, "2001122329", "01122329", "HYUN JUN SHIN", "CL2", "010-4233-7244", "20030105", "EX");
-	IsEmployeeInfoMatched(dataBase, "2008108827", "08108827", "HYUN JUN SHIN", "CL2", "010-4233-7244", "20030105", "EX");
-	IsEmployeeInfoMatched(dataBase, "1985125741", "85125741", "HYUN JUN SHIN", "CL2", "010-4233-7244", "20030105", "EX");
+	IsEmployeeInfoMatched(dataBase, 2001122329, "01122329", "HYUN JUN SHIN", "CL2", "010-4233-7244", "20030105", "EX");
+	IsEmployeeInfoMatched(dataBase, 2008108827, "08108827", "HYUN JUN SHIN", "CL2", "010-4233-7244", "20030105", "EX");
+	IsEmployeeInfoMatched(dataBase, 1985125741, "85125741", "HYUN JUN SHIN", "CL2", "010-4233-7244", "20030105", "EX");
 
 }
 
 
 
 TEST(OPERATORTEST, ModifyOperatorNegativeTest) {
-	std::map<std::string, EmployeeInfo> dataBase;
+	std::map<int, EmployeeInfo> dataBase;
 	Operator* pAddOper = new AddOperator(&dataBase);
 	Operator* pModOper = new ModifyOperator(&dataBase);
 
-	std::map<std::string, EmployeeInfo> searchedModDataBase;
+	std::map<int, EmployeeInfo> searchedModDataBase;
 
 	ParserResult addParserResult = { OPERATION_TYPE::ADD,
 								OPTION1::NONE,
@@ -186,23 +186,23 @@ TEST(OPERATORTEST, ModifyOperatorNegativeTest) {
 
 	EXPECT_EQ(dataBase.size(), 3);
 
-	searchedModDataBase["2001122329"] = EmployeeInfo{ "01122329", "DN WD", "CL4", "010-7174-5680", "20071117", "PRO" };
-	searchedModDataBase["2008108827"] = EmployeeInfo{ "08108827", "RTAH VNUP", "CL3", "010-9031-2726", "19780417", "ADV" };
-	searchedModDataBase["1985125741"] = EmployeeInfo{ "85125741", "FBAH RTIJ", "CL1", "010-8900-1478", "19780228", "ADV" };
+	searchedModDataBase[2001122329] = EmployeeInfo{ "01122329", "DN WD", "CL4", "010-7174-5680", "20071117", "PRO" };
+	searchedModDataBase[2008108827] = EmployeeInfo{ "08108827", "RTAH VNUP", "CL3", "010-9031-2726", "19780417", "ADV" };
+	searchedModDataBase[1985125741] = EmployeeInfo{ "85125741", "FBAH RTIJ", "CL1", "010-8900-1478", "19780228", "ADV" };
 
 
 	addParserResult.changeColumn = "employeeNum";
 	addParserResult.changeData = "28360004";
 	pModOper->operate(&searchedModDataBase, addParserResult);
 
-	EXPECT_FALSE(dataBase["2028360004"].employeeNum == "28360004");
-	EXPECT_TRUE(dataBase["2001122329"].employeeNum == "01122329");
+	EXPECT_FALSE(dataBase[2028360004].employeeNum == "28360004");
+	EXPECT_TRUE(dataBase[2001122329].employeeNum == "01122329");
 
-	EXPECT_FALSE(dataBase["2028360004"].employeeNum == "28360004");
-	EXPECT_TRUE(dataBase["2008108827"].employeeNum == "08108827");
+	EXPECT_FALSE(dataBase[2028360004].employeeNum == "28360004");
+	EXPECT_TRUE(dataBase[2008108827].employeeNum == "08108827");
 
-	EXPECT_FALSE(dataBase["2028360004"].employeeNum == "28360004");
-	EXPECT_TRUE(dataBase["1985125741"].employeeNum == "85125741");
+	EXPECT_FALSE(dataBase[2028360004].employeeNum == "28360004");
+	EXPECT_TRUE(dataBase[1985125741].employeeNum == "85125741");
 	
 }
 

--- a/dynamic/Printer.cpp
+++ b/dynamic/Printer.cpp
@@ -35,7 +35,7 @@ namespace {
 	}
 }
 
-std::string Printer::getPrintString(const ParserResult& parserResult, const std::map<std::string, EmployeeInfo>& targetEmployees)
+std::string Printer::getPrintString(const ParserResult& parserResult, const std::map<int, EmployeeInfo>& targetEmployees)
 {
 	std::string result;
 

--- a/dynamic/Printer.h
+++ b/dynamic/Printer.h
@@ -5,5 +5,5 @@
 
 class Printer {
 public:
-	static std::string getPrintString(const ParserResult& parserResult, const std::map<std::string, EmployeeInfo>& targetEmployees);
+	static std::string getPrintString(const ParserResult& parserResult, const std::map<int, EmployeeInfo>& targetEmployees);
 };

--- a/dynamic/PrinterTest.cpp
+++ b/dynamic/PrinterTest.cpp
@@ -3,29 +3,29 @@
 #include <vector>
 
 TEST(Printer, NullTest) {
-	EXPECT_EQ(Printer::getPrintString(ParserResult(), std::map<std::string, EmployeeInfo>()), "");
+	EXPECT_EQ(Printer::getPrintString(ParserResult(), std::map<int, EmployeeInfo>()), "");
 }
 
 TEST(Printer, EmptyTest) {
 	ParserResult empty_result;
 	empty_result.operationType = OPERATION_TYPE::ADD;
-	EXPECT_EQ(Printer::getPrintString(empty_result, std::map<std::string, EmployeeInfo>()), "");
+	EXPECT_EQ(Printer::getPrintString(empty_result, std::map<int, EmployeeInfo>()), "");
 
 	empty_result.operationType = OPERATION_TYPE::DEL;
-	EXPECT_EQ(Printer::getPrintString(empty_result, std::map<std::string, EmployeeInfo>()), "DEL,NONE\n");
+	EXPECT_EQ(Printer::getPrintString(empty_result, std::map<int, EmployeeInfo>()), "DEL,NONE\n");
 
 	empty_result.operationType = OPERATION_TYPE::SCH;
-	EXPECT_EQ(Printer::getPrintString(empty_result, std::map<std::string, EmployeeInfo>()), "SCH,NONE\n");
+	EXPECT_EQ(Printer::getPrintString(empty_result, std::map<int, EmployeeInfo>()), "SCH,NONE\n");
 
 	empty_result.operationType = OPERATION_TYPE::MOD;
-	EXPECT_EQ(Printer::getPrintString(empty_result, std::map<std::string, EmployeeInfo>()), "MOD,NONE\n");
+	EXPECT_EQ(Printer::getPrintString(empty_result, std::map<int, EmployeeInfo>()), "MOD,NONE\n");
 }
 
 TEST(Printer, BriefPrintTest) {
-	std::map<std::string, EmployeeInfo> employees;
-	employees["1991351446"] = EmployeeInfo{ "91351446", "LIM PNQN", "CL3", "010-6094-6223", "19700122", "PRO" };
-	employees["1993916535"] = EmployeeInfo{ "93916535", "JANG YHFQ", "CL3", "010-1509-9243", "19580525", "PRO" };
-	employees["2007843022"] = EmployeeInfo{ "07843022", "SEO KFI", "CL3", "010-4837-6716", "19810630", "ADV" };
+	std::map<int, EmployeeInfo> employees;
+	employees[1991351446] = EmployeeInfo{ "91351446", "LIM PNQN", "CL3", "010-6094-6223", "19700122", "PRO" };
+	employees[1993916535] = EmployeeInfo{ "93916535", "JANG YHFQ", "CL3", "010-1509-9243", "19580525", "PRO" };
+	employees[2007843022] = EmployeeInfo{ "07843022", "SEO KFI", "CL3", "010-4837-6716", "19810630", "ADV" };
 
 	ParserResult empty_result;
 	empty_result.option1 = OPTION1::NONE;
@@ -43,10 +43,10 @@ TEST(Printer, BriefPrintTest) {
 }
 
 TEST(Printer, DetailPrintTest) {
-	std::map<std::string, EmployeeInfo> employees;
-	employees["1991351446"] = EmployeeInfo{ "91351446", "LIM PNQN", "CL3", "010-6094-6223", "19700122", "PRO" };
-	employees["1993916535"] = EmployeeInfo{ "93916535", "JANG YHFQ", "CL3", "010-1509-9243", "19580525", "PRO" };
-	employees["2007843022"] = EmployeeInfo{ "07843022", "SEO KFI", "CL3", "010-4837-6716", "19810630", "ADV" };
+	std::map<int, EmployeeInfo> employees;
+	employees[1991351446] = EmployeeInfo{ "91351446", "LIM PNQN", "CL3", "010-6094-6223", "19700122", "PRO" };
+	employees[1993916535] = EmployeeInfo{ "93916535", "JANG YHFQ", "CL3", "010-1509-9243", "19580525", "PRO" };
+	employees[2007843022] = EmployeeInfo{ "07843022", "SEO KFI", "CL3", "010-4837-6716", "19810630", "ADV" };
 
 	ParserResult empty_result;
 	empty_result.option1 = OPTION1::P;
@@ -76,11 +76,11 @@ MOD,07843022,SEO KFI,CL3,010-4837-6716,19810630,ADV\n"
 }
 
 TEST(Printer, DetailPrintSortedTest) {
-	std::map<std::string, EmployeeInfo> employees;
-	employees["2007843022"] = EmployeeInfo{ "07843022", "SEO KFI", "CL3", "010-4837-6716", "19810630", "ADV" };
-	employees["1991351446"] = EmployeeInfo{ "91351446", "LIM PNQN", "CL3", "010-6094-6223", "19700122", "PRO" };
-	employees["2018050301"] = EmployeeInfo{ "18050301", "KIM JANG", "CL2", "010-2317-6311", "19940330", "EX" };
-	employees["1993916535"] = EmployeeInfo{ "93916535", "JANG YHFQ", "CL3", "010-1509-9243", "19580525", "PRO" };
+	std::map<int, EmployeeInfo> employees;
+	employees[2007843022] = EmployeeInfo{ "07843022", "SEO KFI", "CL3", "010-4837-6716", "19810630", "ADV" };
+	employees[1991351446] = EmployeeInfo{ "91351446", "LIM PNQN", "CL3", "010-6094-6223", "19700122", "PRO" };
+	employees[2018050301] = EmployeeInfo{ "18050301", "KIM JANG", "CL2", "010-2317-6311", "19940330", "EX" };
+	employees[1993916535] = EmployeeInfo{ "93916535", "JANG YHFQ", "CL3", "010-1509-9243", "19580525", "PRO" };
 	
 
 	ParserResult empty_result;
@@ -114,13 +114,13 @@ MOD,18050301,KIM JANG,CL2,010-2317-6311,19940330,EX\n"
 }
 
 TEST(Printer, DetailPrintBiggerThanFiveTest) {
-	std::map<std::string, EmployeeInfo> employees;
-	employees["2007843022"] = EmployeeInfo{ "07843022", "SEO KFI", "CL3", "010-4837-6716", "19810630", "ADV" };
-	employees["1991351446"] = EmployeeInfo{ "91351446", "LIM PNQN", "CL3", "010-6094-6223", "19700122", "PRO" };
-	employees["2018050301"] = EmployeeInfo{ "18050301", "KIM JANG", "CL2", "010-2317-6311", "19940330", "EX" };
-	employees["2001122329"] = EmployeeInfo{ "01122329", "DN WD", "CL4", "010-7174-5680", "20071117", "PRO" };
-	employees["2008108827"] = EmployeeInfo{ "08108827", "RTAH VNUP", "CL3", "010-9031-2726", "19780417", "ADV" };
-	employees["1985125741"] = EmployeeInfo{ "85125741", "FBAH RTIJ", "CL1", "010-8900-1478", "19780228", "ADV" };
+	std::map<int, EmployeeInfo> employees;
+	employees[2007843022] = EmployeeInfo{ "07843022", "SEO KFI", "CL3", "010-4837-6716", "19810630", "ADV" };
+	employees[1991351446] = EmployeeInfo{ "91351446", "LIM PNQN", "CL3", "010-6094-6223", "19700122", "PRO" };
+	employees[2018050301] = EmployeeInfo{ "18050301", "KIM JANG", "CL2", "010-2317-6311", "19940330", "EX" };
+	employees[2001122329] = EmployeeInfo{ "01122329", "DN WD", "CL4", "010-7174-5680", "20071117", "PRO" };
+	employees[2008108827] = EmployeeInfo{ "08108827", "RTAH VNUP", "CL3", "010-9031-2726", "19780417", "ADV" };
+	employees[1985125741] = EmployeeInfo{ "85125741", "FBAH RTIJ", "CL1", "010-8900-1478", "19780228", "ADV" };
 
 	ParserResult empty_result;
 	empty_result.option1 = OPTION1::P;

--- a/dynamic/Searcher.cpp
+++ b/dynamic/Searcher.cpp
@@ -6,10 +6,10 @@
 
 using namespace std;
 
-map<string, EmployeeInfo> EmployeeNumSearcher::search(const ParserResult& parserResult) const {
-	map<string, EmployeeInfo> searchedInfo;
+map<int, EmployeeInfo> EmployeeNumSearcher::search(const ParserResult& parserResult) const {
+	map<int, EmployeeInfo> searchedInfo;
 
-	string key = getKeyFromEmployeeNum(parserResult.searchData);
+	int key = getKeyFromEmployeeNum(parserResult.searchData);
 	if ((*pDataBase_).count(key)) {
 		searchedInfo[key] = (*pDataBase_)[key];
 	}
@@ -17,8 +17,8 @@ map<string, EmployeeInfo> EmployeeNumSearcher::search(const ParserResult& parser
 	return searchedInfo;
 }
 
-map<string, EmployeeInfo> NameSearcher::search(const ParserResult& parserResult) const {
-	map<string, EmployeeInfo> searchedInfo;
+map<int, EmployeeInfo> NameSearcher::search(const ParserResult& parserResult) const {
+	map<int, EmployeeInfo> searchedInfo;
 
 	for (const auto& dbInfo : (*pDataBase_)) {
 		if (parserResult.searchData == filterData(dbInfo.second.name, parserResult.option2)) {
@@ -50,8 +50,8 @@ string NameSearcher::filterData(const string& name, const OPTION2 nameOption) co
 	throw invalid_argument("ERROR: Invalid Name Option2");
 }
 
-map<string, EmployeeInfo> ClSearcher::search(const ParserResult& parserResult) const {
-	map<string, EmployeeInfo> searchedInfo;
+map<int, EmployeeInfo> ClSearcher::search(const ParserResult& parserResult) const {
+	map<int, EmployeeInfo> searchedInfo;
 
 	for (const auto& dbInfo : (*pDataBase_)) {
 		if (parserResult.searchData == dbInfo.second.cl) {
@@ -62,8 +62,8 @@ map<string, EmployeeInfo> ClSearcher::search(const ParserResult& parserResult) c
 	return searchedInfo;
 }
 
-map<string, EmployeeInfo> PhoneNumberSearcher::search(const ParserResult& parserResult) const {
-	map<string, EmployeeInfo> searchedInfo;
+map<int, EmployeeInfo> PhoneNumberSearcher::search(const ParserResult& parserResult) const {
+	map<int, EmployeeInfo> searchedInfo;
 
 	for (const auto& dbInfo : (*pDataBase_)) {
 		if (parserResult.searchData == filterData(dbInfo.second.phoneNum, parserResult.option2)) {
@@ -95,8 +95,8 @@ string PhoneNumberSearcher::filterData(const string& phoneNum, const OPTION2 num
 	throw invalid_argument("ERROR: Invalid Phone Number Option2");
 }
 
-map<string, EmployeeInfo> BirthdaySearcher::search(const ParserResult& parserResult) const {
-	map<string, EmployeeInfo> searchedInfo;
+map<int, EmployeeInfo> BirthdaySearcher::search(const ParserResult& parserResult) const {
+	map<int, EmployeeInfo> searchedInfo;
 
 	for (const auto& dbInfo : (*pDataBase_)) {
 		if (parserResult.searchData == filterData(dbInfo.second.birthday, parserResult.option2)) {
@@ -127,8 +127,8 @@ string BirthdaySearcher::filterData(const string& birthDay, const OPTION2 birthO
 	throw invalid_argument("ERROR: Invalid Birthday Option2");
 }
 
-map<string, EmployeeInfo> CertiSearcher::search(const ParserResult& parserResult) const {
-	map<string, EmployeeInfo> searchedInfo;
+map<int, EmployeeInfo> CertiSearcher::search(const ParserResult& parserResult) const {
+	map<int, EmployeeInfo> searchedInfo;
 
 	for (const auto& dbInfo : (*pDataBase_)) {
 		if (parserResult.searchData == dbInfo.second.certi) {

--- a/dynamic/Searcher.h
+++ b/dynamic/Searcher.h
@@ -6,27 +6,27 @@
 class Searcher {
 public:
 	virtual ~Searcher() {}
-	Searcher(std::map<std::string, EmployeeInfo>* pDataBase) : pDataBase_(pDataBase) {}
-	virtual std::map<std::string, EmployeeInfo> search(const ParserResult& parserResult) const = 0;
+	Searcher(std::map<int, EmployeeInfo>* pDataBase) : pDataBase_(pDataBase) {}
+	virtual std::map<int, EmployeeInfo> search(const ParserResult& parserResult) const = 0;
 
 protected:
-	std::map<std::string, EmployeeInfo>* pDataBase_;
+	std::map<int, EmployeeInfo>* pDataBase_;
 };
 
 class EmployeeNumSearcher : public Searcher {
 public:
-	EmployeeNumSearcher(std::map<std::string, EmployeeInfo>* pDataBase) : Searcher(pDataBase) {}
+	EmployeeNumSearcher(std::map<int, EmployeeInfo>* pDataBase) : Searcher(pDataBase) {}
 
 private:
-	virtual std::map<std::string, EmployeeInfo> search(const ParserResult& parserResult) const override;
+	virtual std::map<int, EmployeeInfo> search(const ParserResult& parserResult) const override;
 };
 
 class NameSearcher : public Searcher {
 public:
-	NameSearcher(std::map<std::string, EmployeeInfo>* pDataBase) : Searcher(pDataBase) {}
+	NameSearcher(std::map<int, EmployeeInfo>* pDataBase) : Searcher(pDataBase) {}
 
 private:
-	virtual std::map<std::string, EmployeeInfo> search(const ParserResult& parserResult) const override;
+	virtual std::map<int, EmployeeInfo> search(const ParserResult& parserResult) const override;
 	std::string filterData(const std::string& name, const OPTION2 option) const;
 
 private:
@@ -37,18 +37,18 @@ private:
 
 class ClSearcher : public Searcher {
 public:
-	ClSearcher(std::map<std::string, EmployeeInfo>* pDataBase) : Searcher(pDataBase) {}
+	ClSearcher(std::map<int, EmployeeInfo>* pDataBase) : Searcher(pDataBase) {}
 
 private:
-	virtual std::map<std::string, EmployeeInfo> search(const ParserResult& parserResult) const override;
+	virtual std::map<int, EmployeeInfo> search(const ParserResult& parserResult) const override;
 };
 
 class PhoneNumberSearcher : public Searcher {
 public:
-	PhoneNumberSearcher(std::map<std::string, EmployeeInfo>* pDataBase) : Searcher(pDataBase) {}
+	PhoneNumberSearcher(std::map<int, EmployeeInfo>* pDataBase) : Searcher(pDataBase) {}
 
 private:
-	virtual std::map<std::string, EmployeeInfo> search(const ParserResult& parserResult) const override;
+	virtual std::map<int, EmployeeInfo> search(const ParserResult& parserResult) const override;
 	std::string filterData(const std::string& phoneNumber, const OPTION2 numberOption) const;
 
 private:
@@ -59,10 +59,10 @@ private:
 
 class BirthdaySearcher : public Searcher {
 public:
-	BirthdaySearcher(std::map<std::string, EmployeeInfo>* pDataBase) : Searcher(pDataBase) {}
+	BirthdaySearcher(std::map<int, EmployeeInfo>* pDataBase) : Searcher(pDataBase) {}
 
 private:
-	virtual std::map<std::string, EmployeeInfo> search(const ParserResult& parserResult) const override;
+	virtual std::map<int, EmployeeInfo> search(const ParserResult& parserResult) const override;
 	std::string filterData(const std::string& birthDay, const OPTION2 birthOption) const;
 
 private:
@@ -76,10 +76,10 @@ private:
 
 class CertiSearcher : public Searcher {
 public:
-	CertiSearcher(std::map<std::string, EmployeeInfo>* pDataBase) : Searcher(pDataBase) {}
+	CertiSearcher(std::map<int, EmployeeInfo>* pDataBase) : Searcher(pDataBase) {}
 
 private:
-	virtual std::map<std::string, EmployeeInfo> search(const ParserResult& parserResult) const override;
+	virtual std::map<int, EmployeeInfo> search(const ParserResult& parserResult) const override;
 };
 
 class IFactorySearcher {
@@ -90,7 +90,7 @@ public:
 
 class FactorySearcher : public IFactorySearcher {
 public:
-	FactorySearcher(std::map<std::string, EmployeeInfo>* pDataBase) {
+	FactorySearcher(std::map<int, EmployeeInfo>* pDataBase) {
 		pEmployeeNumSearcher_ = new EmployeeNumSearcher(pDataBase);
 		pNameSearcher_ = new NameSearcher(pDataBase);
 		pClSearcher_ = new ClSearcher(pDataBase);

--- a/dynamic/SearcherTest.cpp
+++ b/dynamic/SearcherTest.cpp
@@ -15,290 +15,290 @@ bool compareEmployeeInfo(const EmployeeInfo& info1, const EmployeeInfo& info2) {
 }
 
 TEST(EmployeeNumSearchTest, NoOptionTest) {
-	map<string, EmployeeInfo> dataBase;
-	dataBase["2018051224"] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
-	dataBase["2017256132"] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
-	dataBase["2020031242"] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
-	dataBase["2014321152"] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
-	dataBase["2012035123"] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
-	dataBase["2008051231"] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
+	map<int, EmployeeInfo> dataBase;
+	dataBase[2018051224] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
+	dataBase[2017256132] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
+	dataBase[2020031242] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
+	dataBase[2014321152] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
+	dataBase[2012035123] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
+	dataBase[2008051231] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
 
 	Searcher* pSearcher = new EmployeeNumSearcher(&dataBase);
 
-	map<string, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "employeeNum", "18051224", "", "" }));
+	map<int, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "employeeNum", "18051224", "", "" }));
 	EXPECT_EQ(1, result1.size());
-	EXPECT_EQ(1, result1.count("2018051224"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" }), result1["2018051224"]));
+	EXPECT_EQ(1, result1.count(2018051224));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" }), result1[2018051224]));
 
-	map<string, EmployeeInfo> result2 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "employeeNum", "17256132", "", "" }));
+	map<int, EmployeeInfo> result2 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "employeeNum", "17256132", "", "" }));
 	EXPECT_EQ(1, result2.size());
-	EXPECT_EQ(1, result2.count("2017256132"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" }), result2["2017256132"]));
-	EXPECT_FALSE(compareEmployeeInfo(EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" }), result2["2017256132"]));
+	EXPECT_EQ(1, result2.count(2017256132));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" }), result2[2017256132]));
+	EXPECT_FALSE(compareEmployeeInfo(EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" }), result2[2017256132]));
 
-	map<string, EmployeeInfo> result3 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "employeeNum", "08051231", "", "" }));
+	map<int, EmployeeInfo> result3 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "employeeNum", "08051231", "", "" }));
 	EXPECT_EQ(1, result3.size());
-	EXPECT_EQ(1, result3.count("2008051231"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" }), result3["2008051231"]));
+	EXPECT_EQ(1, result3.count(2008051231));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" }), result3[2008051231]));
 
 	delete pSearcher;
 }
 
 TEST(NameSearchTest, NoOptionTest) {
-	map<string, EmployeeInfo> dataBase;
-	dataBase["2018051224"] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
-	dataBase["2017256132"] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
-	dataBase["2020031242"] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
-	dataBase["2014321152"] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
-	dataBase["2012035123"] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
-	dataBase["2008051231"] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
+	map<int, EmployeeInfo> dataBase;
+	dataBase[2018051224] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
+	dataBase[2017256132] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
+	dataBase[2020031242] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
+	dataBase[2014321152] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
+	dataBase[2012035123] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
+	dataBase[2008051231] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
 
 	Searcher* pSearcher = new NameSearcher(&dataBase);
 
-	map<string, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "name", "JUNHYUCK SHIN", "", "" }));
+	map<int, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "name", "JUNHYUCK SHIN", "", "" }));
 	EXPECT_EQ(1, result1.size());
-	EXPECT_EQ(1, result1.count("2017256132"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" }), result1["2017256132"]));
+	EXPECT_EQ(1, result1.count(2017256132));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" }), result1[2017256132]));
 
-	map<string, EmployeeInfo> result2 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "name", "KIM INSU", "", "" }));
+	map<int, EmployeeInfo> result2 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "name", "KIM INSU", "", "" }));
 	EXPECT_EQ(0, result2.size());
 
 	delete pSearcher;
 }
 
 TEST(NameSearchTest, OptionTest) {
-	map<string, EmployeeInfo> dataBase;
-	dataBase["2018051224"] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
-	dataBase["2017256132"] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
-	dataBase["2020031242"] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
-	dataBase["2014321152"] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
-	dataBase["2012035123"] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
-	dataBase["2008051231"] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
+	map<int, EmployeeInfo> dataBase;
+	dataBase[2018051224] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
+	dataBase[2017256132] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
+	dataBase[2020031242] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
+	dataBase[2014321152] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
+	dataBase[2012035123] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
+	dataBase[2008051231] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
 
 	Searcher* pSearcher = new NameSearcher(&dataBase);
 
-	map<string, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::F, OPTION3::NONE, "name", "YEONGCHUL", "", "" }));
+	map<int, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::F, OPTION3::NONE, "name", "YEONGCHUL", "", "" }));
 	EXPECT_EQ(1, result1.size());
-	EXPECT_EQ(1, result1.count("2018051224"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" }), result1["2018051224"]));
+	EXPECT_EQ(1, result1.count(2018051224));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" }), result1[2018051224]));
 
-	map<string, EmployeeInfo> result2 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::L, OPTION3::NONE, "name", "KIM", "", "" }));
+	map<int, EmployeeInfo> result2 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::L, OPTION3::NONE, "name", "KIM", "", "" }));
 	EXPECT_EQ(2, result2.size());
-	EXPECT_EQ(1, result2.count("2014321152"));
-	EXPECT_EQ(1, result2.count("2012035123"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" }), result2["2014321152"]));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" }), result2["2012035123"]));
+	EXPECT_EQ(1, result2.count(2014321152));
+	EXPECT_EQ(1, result2.count(2012035123));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" }), result2[2014321152]));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" }), result2[2012035123]));
 
-	map<string, EmployeeInfo> result3 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::F, OPTION3::NONE, "name", "CHO", "", "" }));
+	map<int, EmployeeInfo> result3 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::F, OPTION3::NONE, "name", "CHO", "", "" }));
 	EXPECT_EQ(0, result3.size());
 
 	delete pSearcher;
 }
 
 TEST(ClSearchTest, NoOptionTest) {
-	map<string, EmployeeInfo> dataBase;
-	dataBase["2018051224"] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
-	dataBase["2017256132"] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
-	dataBase["2020031242"] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
-	dataBase["2014321152"] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
-	dataBase["2012035123"] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
-	dataBase["2008051231"] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
+	map<int, EmployeeInfo> dataBase;
+	dataBase[2018051224] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
+	dataBase[2017256132] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
+	dataBase[2020031242] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
+	dataBase[2014321152] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
+	dataBase[2012035123] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
+	dataBase[2008051231] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
 
 	Searcher* pSearcher = new ClSearcher(&dataBase);
 
-	map<string, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::L, OPTION3::NONE, "cl", "CL2", "", "" }));
+	map<int, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::L, OPTION3::NONE, "cl", "CL2", "", "" }));
 	EXPECT_EQ(4, result1.size());
-	EXPECT_EQ(1, result1.count("2018051224"));
-	EXPECT_EQ(1, result1.count("2017256132"));
-	EXPECT_EQ(1, result1.count("2020031242"));
-	EXPECT_EQ(1, result1.count("2014321152"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" }), result1["2018051224"]));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" }), result1["2017256132"]));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" }), result1["2020031242"]));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" }), result1["2014321152"]));
+	EXPECT_EQ(1, result1.count(2018051224));
+	EXPECT_EQ(1, result1.count(2017256132));
+	EXPECT_EQ(1, result1.count(2020031242));
+	EXPECT_EQ(1, result1.count(2014321152));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" }), result1[2018051224]));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" }), result1[2017256132]));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" }), result1[2020031242]));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" }), result1[2014321152]));
 
-	map<string, EmployeeInfo> result2 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::L, OPTION3::NONE, "cl", "CL3", "", "" }));
+	map<int, EmployeeInfo> result2 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::L, OPTION3::NONE, "cl", "CL3", "", "" }));
 	EXPECT_EQ(1, result2.size());
-	EXPECT_EQ(1, result2.count("2012035123"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" }), result2["2012035123"]));
+	EXPECT_EQ(1, result2.count(2012035123));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" }), result2[2012035123]));
 
-	map<string, EmployeeInfo> result3 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::L, OPTION3::NONE, "cl", "CL4", "", "" }));
+	map<int, EmployeeInfo> result3 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::L, OPTION3::NONE, "cl", "CL4", "", "" }));
 	EXPECT_EQ(1, result3.size());
-	EXPECT_EQ(1, result3.count("2008051231"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" }), result3["2008051231"]));
+	EXPECT_EQ(1, result3.count(2008051231));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" }), result3[2008051231]));
 
 	delete pSearcher;
 }
 
 TEST(PhoneNumberSearchTest, NoOptionTest) {
-	map<string, EmployeeInfo> dataBase;
-	dataBase["2018051224"] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
-	dataBase["2017256132"] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
-	dataBase["2020031242"] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
-	dataBase["2014321152"] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
-	dataBase["2012035123"] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
-	dataBase["2008051231"] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
+	map<int, EmployeeInfo> dataBase;
+	dataBase[2018051224] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
+	dataBase[2017256132] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
+	dataBase[2020031242] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
+	dataBase[2014321152] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
+	dataBase[2012035123] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
+	dataBase[2008051231] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
 
 	Searcher* pSearcher = new PhoneNumberSearcher(&dataBase);
 
-	map<string, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "phoneNum", "010-6855-9852", "", "" }));
+	map<int, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "phoneNum", "010-6855-9852", "", "" }));
 	EXPECT_EQ(1, result1.size());
-	EXPECT_EQ(1, result1.count("2012035123"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" }), result1["2012035123"]));
+	EXPECT_EQ(1, result1.count(2012035123));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" }), result1[2012035123]));
 
-	map<string, EmployeeInfo> result2 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "phoneNum", "010-2135-1546", "", "" }));
+	map<int, EmployeeInfo> result2 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "phoneNum", "010-2135-1546", "", "" }));
 	EXPECT_EQ(1, result2.size());
-	EXPECT_EQ(1, result2.count("2017256132"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" }), result2["2017256132"]));
+	EXPECT_EQ(1, result2.count(2017256132));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" }), result2[2017256132]));
 
 	delete pSearcher;
 }
 
 TEST(PhoneNumberSearchTest, OptionTest) {
-	map<string, EmployeeInfo> dataBase;
-	dataBase["2018051224"] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
-	dataBase["2017256132"] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
-	dataBase["2020031242"] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
-	dataBase["2014321152"] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
-	dataBase["2012035123"] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
-	dataBase["2008051231"] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
+	map<int, EmployeeInfo> dataBase;
+	dataBase[2018051224] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
+	dataBase[2017256132] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
+	dataBase[2020031242] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
+	dataBase[2014321152] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
+	dataBase[2012035123] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
+	dataBase[2008051231] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
 
 	Searcher* pSearcher = new PhoneNumberSearcher(&dataBase);
 
-	map<string, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::M, OPTION3::NONE, "phoneNum", "4756", "", "" }));
+	map<int, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::M, OPTION3::NONE, "phoneNum", "4756", "", "" }));
 	EXPECT_EQ(1, result1.size());
-	EXPECT_EQ(1, result1.count("2020031242"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" }), result1["2020031242"]));
+	EXPECT_EQ(1, result1.count(2020031242));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" }), result1[2020031242]));
 
-	map<string, EmployeeInfo> result2 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::L, OPTION3::NONE, "phoneNum", "9852", "", "" }));
+	map<int, EmployeeInfo> result2 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::L, OPTION3::NONE, "phoneNum", "9852", "", "" }));
 	EXPECT_EQ(1, result2.size());
-	EXPECT_EQ(1, result2.count("2012035123"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" }), result2["2012035123"]));
+	EXPECT_EQ(1, result2.count(2012035123));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" }), result2[2012035123]));
 
 	delete pSearcher;
 }
 
 TEST(BirthdaySearchTest, NoOptionTest) {
-	map<string, EmployeeInfo> dataBase;
-	dataBase["2018051224"] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
-	dataBase["2017256132"] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
-	dataBase["2020031242"] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
-	dataBase["2014321152"] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
-	dataBase["2012035123"] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
-	dataBase["2008051231"] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
+	map<int, EmployeeInfo> dataBase;
+	dataBase[2018051224] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
+	dataBase[2017256132] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
+	dataBase[2020031242] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
+	dataBase[2014321152] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
+	dataBase[2012035123] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
+	dataBase[2008051231] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
 
 	Searcher* pSearcher = new BirthdaySearcher(&dataBase);
 
-	map<string, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "birthday", "19910415", "", "" }));
+	map<int, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "birthday", "19910415", "", "" }));
 	EXPECT_EQ(1, result1.size());
-	EXPECT_EQ(1, result1.count("2014321152"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" }), result1["2014321152"]));
+	EXPECT_EQ(1, result1.count(2014321152));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" }), result1[2014321152]));
 
-	map<string, EmployeeInfo> result2 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "birthday", "19930821", "", "" }));
+	map<int, EmployeeInfo> result2 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "birthday", "19930821", "", "" }));
 	EXPECT_EQ(1, result2.size());
-	EXPECT_EQ(1, result2.count("2020031242"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" }), result2["2020031242"]));
+	EXPECT_EQ(1, result2.count(2020031242));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" }), result2[2020031242]));
 
 	delete pSearcher;
 }
 
 TEST(BirthdaySearchTest, OptionTest) {
-	map<string, EmployeeInfo> dataBase;
-	dataBase["2018051224"] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
-	dataBase["2017256132"] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
-	dataBase["2020031242"] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
-	dataBase["2014321152"] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
-	dataBase["2012035123"] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
-	dataBase["2008051231"] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
+	map<int, EmployeeInfo> dataBase;
+	dataBase[2018051224] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
+	dataBase[2017256132] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
+	dataBase[2020031242] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
+	dataBase[2014321152] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
+	dataBase[2012035123] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
+	dataBase[2008051231] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
 
 	Searcher* pSearcher = new BirthdaySearcher(&dataBase);
 
-	map<string, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::Y, OPTION3::NONE, "birthday", "1991", "", "" }));
+	map<int, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::Y, OPTION3::NONE, "birthday", "1991", "", "" }));
 	EXPECT_EQ(2, result1.size());
-	EXPECT_EQ(1, result1.count("2017256132"));
-	EXPECT_EQ(1, result1.count("2014321152"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" }), result1["2017256132"]));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" }), result1["2014321152"]));
+	EXPECT_EQ(1, result1.count(2017256132));
+	EXPECT_EQ(1, result1.count(2014321152));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" }), result1[2017256132]));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" }), result1[2014321152]));
 
-	map<string, EmployeeInfo> result2 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::M, OPTION3::NONE, "birthday", "01", "", "" }));
+	map<int, EmployeeInfo> result2 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::M, OPTION3::NONE, "birthday", "01", "", "" }));
 	EXPECT_EQ(1, result2.size());
-	EXPECT_EQ(1, result2.count("2018051224"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" }), result2["2018051224"]));
+	EXPECT_EQ(1, result2.count(2018051224));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" }), result2[2018051224]));
 
-	map<string, EmployeeInfo> result3 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::D, OPTION3::NONE, "birthday", "20", "", "" }));
+	map<int, EmployeeInfo> result3 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::D, OPTION3::NONE, "birthday", "20", "", "" }));
 	EXPECT_EQ(2, result3.size());
-	EXPECT_EQ(1, result3.count("2012035123"));
-	EXPECT_EQ(1, result3.count("2008051231"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" }), result3["2012035123"]));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" }), result3["2008051231"]));
+	EXPECT_EQ(1, result3.count(2012035123));
+	EXPECT_EQ(1, result3.count(2008051231));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" }), result3[2012035123]));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" }), result3[2008051231]));
 
 	delete pSearcher;
 }
 
 TEST(CertiSearchTest, NoOptionTest) {
-	map<string, EmployeeInfo> dataBase;
-	dataBase["2018051224"] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
-	dataBase["2017256132"] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
-	dataBase["2020031242"] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
-	dataBase["2014321152"] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
-	dataBase["2012035123"] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
-	dataBase["2008051231"] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
+	map<int, EmployeeInfo> dataBase;
+	dataBase[2018051224] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
+	dataBase[2017256132] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
+	dataBase[2020031242] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
+	dataBase[2014321152] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
+	dataBase[2012035123] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
+	dataBase[2008051231] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
 
 	Searcher* pSearcher = new CertiSearcher(&dataBase);
 
-	map<string, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::Y, OPTION3::NONE, "certi", "PRO", "", "" }));
+	map<int, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::Y, OPTION3::NONE, "certi", "PRO", "", "" }));
 	EXPECT_EQ(4, result1.size());
-	EXPECT_EQ(1, result1.count("2018051224"));
-	EXPECT_EQ(1, result1.count("2020031242"));
-	EXPECT_EQ(1, result1.count("2012035123"));
-	EXPECT_EQ(1, result1.count("2008051231"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" }), result1["2018051224"]));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" }), result1["2020031242"]));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" }), result1["2012035123"]));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" }), result1["2008051231"]));
+	EXPECT_EQ(1, result1.count(2018051224));
+	EXPECT_EQ(1, result1.count(2020031242));
+	EXPECT_EQ(1, result1.count(2012035123));
+	EXPECT_EQ(1, result1.count(2008051231));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" }), result1[2018051224]));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" }), result1[2020031242]));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" }), result1[2012035123]));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" }), result1[2008051231]));
 
 	delete pSearcher;
 }
 
 TEST(FactorySearcherTest, NoOptionTest) {
-	map<string, EmployeeInfo> dataBase;
-	dataBase["2018051224"] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
-	dataBase["2017256132"] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
-	dataBase["2020031242"] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
-	dataBase["2014321152"] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
-	dataBase["2012035123"] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
-	dataBase["2008051231"] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
+	map<int, EmployeeInfo> dataBase;
+	dataBase[2018051224] = EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" });
+	dataBase[2017256132] = EmployeeInfo({ "17256132", "JUNHYUCK SHIN", "CL2" , "010-2135-1546", "19910526", "EX" });
+	dataBase[2020031242] = EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" });
+	dataBase[2014321152] = EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" });
+	dataBase[2012035123] = EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" });
+	dataBase[2008051231] = EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" });
 
 	IFactorySearcher* pFactorySearcher = new FactorySearcher(&dataBase);
 	Searcher* pSearcher = pFactorySearcher->getSearcher(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::Y, OPTION3::NONE, "certi", "PRO", "", "" }));
-	map<string, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::Y, OPTION3::NONE, "certi", "PRO", "", "" }));
+	map<int, EmployeeInfo> result1 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::Y, OPTION3::NONE, "certi", "PRO", "", "" }));
 	EXPECT_EQ(4, result1.size());
-	EXPECT_EQ(1, result1.count("2018051224"));
-	EXPECT_EQ(1, result1.count("2020031242"));
-	EXPECT_EQ(1, result1.count("2012035123"));
-	EXPECT_EQ(1, result1.count("2008051231"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" }), result1["2018051224"]));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" }), result1["2020031242"]));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" }), result1["2012035123"]));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" }), result1["2008051231"]));
+	EXPECT_EQ(1, result1.count(2018051224));
+	EXPECT_EQ(1, result1.count(2020031242));
+	EXPECT_EQ(1, result1.count(2012035123));
+	EXPECT_EQ(1, result1.count(2008051231));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "18051224", "YEONGCHUL CHO", "CL2" , "010-4198-8858", "19930116", "PRO" }), result1[2018051224]));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" }), result1[2020031242]));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" }), result1[2012035123]));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "08051231", "SINHO OH", "CL4" , "010-5563-8744", "19800420", "PRO" }), result1[2008051231]));
 
 	pSearcher = pFactorySearcher->getSearcher(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "employeeNum", "20031242", "", "" }));
-	map<string, EmployeeInfo> result2 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "employeeNum", "20031242", "", "" }));
+	map<int, EmployeeInfo> result2 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "employeeNum", "20031242", "", "" }));
 	EXPECT_EQ(1, result2.size());
-	EXPECT_EQ(1, result2.count("2020031242"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" }), result2["2020031242"]));
+	EXPECT_EQ(1, result2.count(2020031242));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "20031242", "JUNGHOON KONG", "CL2" , "010-4756-9871", "19930821", "PRO" }), result2[2020031242]));
 
 	pSearcher = pFactorySearcher->getSearcher(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "phoneNum", "010-6855-9852", "", "" }));
-	map<string, EmployeeInfo> result4 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "phoneNum", "010-6855-9852", "", "" }));
+	map<int, EmployeeInfo> result4 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "phoneNum", "010-6855-9852", "", "" }));
 	EXPECT_EQ(1, result4.size());
-	EXPECT_EQ(1, result4.count("2012035123"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" }), result4["2012035123"]));
+	EXPECT_EQ(1, result4.count(2012035123));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "12035123", "JONGWON KIM", "CL3" , "010-6855-9852", "19850720", "PRO" }), result4[2012035123]));
 
 	pSearcher = pFactorySearcher->getSearcher(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "birthday", "19910415", "", "" }));
-	map<string, EmployeeInfo> result5 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "birthday", "19910415", "", "" }));
+	map<int, EmployeeInfo> result5 = pSearcher->search(ParserResult({ OPERATION_TYPE::SCH, OPTION1::NONE, OPTION2::NONE, OPTION3::NONE, "birthday", "19910415", "", "" }));
 	EXPECT_EQ(1, result5.size());
-	EXPECT_EQ(1, result5.count("2014321152"));
-	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" }), result5["2014321152"]));
+	EXPECT_EQ(1, result5.count(2014321152));
+	EXPECT_TRUE(compareEmployeeInfo(EmployeeInfo({ "14321152", "INSOO KIM", "CL2" , "010-1312-4356", "19910415", "ADV" }), result5[2014321152]));
 
 	delete pFactorySearcher;
 }


### PR DESCRIPTION
(map<string, EmployeeInfo> -> map<int,EmployeeInfo>)
    1. key 는 년도를 붙여 int로 변환한 사번
    2. 년도를 붙이면, key값은 19XXXXXXXX, 또는 20XXXXXXXX 의 형식을 가짐
       - integer의 범위는 ~2,147,483,647 이므로 overflow에 대한 우려는
	 없음
       - 출력은 EmployeeInfo의 string 형식 사번을 출력하므로 앞의 0이
	 잘릴 우려는 없음